### PR TITLE
Make new recipe forms have one RecipeBagRow at the start

### DIFF
--- a/packages/react-admin/src/components/Dashboard/RecipeEdit.tsx
+++ b/packages/react-admin/src/components/Dashboard/RecipeEdit.tsx
@@ -42,9 +42,9 @@ export const useRecipeEditForm = createDialogForm({
         nonNullable: true
       }),
       bag_names: new forms.FormArray<ReturnType<typeof RecipeBagRow>>(
-        !value ? [] : value.bag_names.map(e => RecipeBagRow(e)), {
-        validators: [forms.Validators.required]
-      }),
+        !value ? [RecipeBagRow({ bag_name: "", with_acl: false })] : value.bag_names.map(e => RecipeBagRow(e)),
+        { validators: [forms.Validators.required] }
+      ),
       plugin_names: new forms.FormControl<string[]>(value?.plugin_names ?? [], {
         nonNullable: true, validators: [],
       }),


### PR DESCRIPTION
At least one bag is needed to make a recipe. It is not noticeable until you click the button for adding a bag. This basically clicks it once for new recipes so users know they need to add a bag.