### PR TITLE
Add `required` attribute to name and description in recipe form

### DIFF
--- a/packages/react-admin/src/components/Dashboard/RecipeEdit.tsx
+++ b/packages/react-admin/src/components/Dashboard/RecipeEdit.tsx
@@ -70,11 +70,13 @@ export const useRecipeEditForm = createDialogForm({
         onChange={onChange(recipeForm.controls.recipe_name)}
         disabled={recipeForm.controls.recipe_name.disabled}
         helperText={recipeForm.controls.recipe_name.disabled && "Recipe name cannot be changed."}
+        required={!recipeForm.controls.recipe_name.disabled}
       />}
       <TextField
         label="Description"
         value={recipeForm.controls.description.value}
         onChange={onChange(recipeForm.controls.description)}
+        required
       />
       <OwnerSelection
         type="recipe"


### PR DESCRIPTION
This adds the stars to the the text fields in the UI. The fields were required in code but not shown required in the UI.