### PR TITLE
Add entries about entities to docs

### DIFF
--- a/editions/mws-docs/tiddlers/Entity Access Control.md
+++ b/editions/mws-docs/tiddlers/Entity Access Control.md
@@ -1,0 +1,2 @@
+Each [[Entity]] has a list of roles and permissions.
+Each row defines which role has what [[permissions|Entity Permissions]] for that entity.

--- a/editions/mws-docs/tiddlers/Entity Access Control.md.meta
+++ b/editions/mws-docs/tiddlers/Entity Access Control.md.meta
@@ -1,0 +1,4 @@
+created: 20250713025613925
+modified: 20250713025619796
+title: Entity Access Control
+type: text/markdown

--- a/editions/mws-docs/tiddlers/Entity Owner.md
+++ b/editions/mws-docs/tiddlers/Entity Owner.md
@@ -1,0 +1,3 @@
+When a user creates an [[Entity]], they can optionally become the owner of the entity. Owners have full [[permission|Entity Permissions]] over the entity. There can only be one or no owner of an entity. 
+
+Entity owners can not transfer ownership to another user. Only site admins can change ownership.

--- a/editions/mws-docs/tiddlers/Entity Owner.md.meta
+++ b/editions/mws-docs/tiddlers/Entity Owner.md.meta
@@ -1,0 +1,4 @@
+created: 20250713030055363
+modified: 20250713030218461
+title: Entity Owner
+type: text/markdown

--- a/editions/mws-docs/tiddlers/Entity Permissions.md
+++ b/editions/mws-docs/tiddlers/Entity Permissions.md
@@ -1,0 +1,7 @@
+There are 3 levels of permissions that can be assigned on the [[Entity Access Control]] list.
+
+* **ADMIN** - Update the access control list. Also granted WRITE and READ.
+* **WRITE** - Create, update, and delete tiddlers. Also granted READ.
+* **READ** -  List and read tiddlers.
+
+The [[owner|Entity Owner]] of the [[Entity]] has full permissions over the entity.

--- a/editions/mws-docs/tiddlers/Entity Permissions.md.meta
+++ b/editions/mws-docs/tiddlers/Entity Permissions.md.meta
@@ -1,0 +1,4 @@
+created: 20250713025717567
+modified: 20250713025751794
+title: Entity Permissions
+type: text/markdown

--- a/editions/mws-docs/tiddlers/Entity.md
+++ b/editions/mws-docs/tiddlers/Entity.md
@@ -1,0 +1,3 @@
+An entity is a [[bag or a recipe|Bags and Recipes]]. 
+
+Configuring what certain roles can do to entities is done with [[Entity Access Control]].

--- a/editions/mws-docs/tiddlers/Entity.md.meta
+++ b/editions/mws-docs/tiddlers/Entity.md.meta
@@ -1,0 +1,5 @@
+created: 20250713025508951
+modified: 20250713025541761
+tags: 
+title: Entity
+type: text/markdown

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiddlywiki/mws",
-  "version": "0.1.0",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiddlywiki/mws",
-      "version": "0.1.0",
+      "version": "0.1.9",
       "license": "BSD-3-Clause",
       "workspaces": [
         "packages/events",
@@ -6284,7 +6284,7 @@
       "name": "@types/tiddlywiki"
     },
     "prisma/client": {
-      "name": "prisma-client-5c34d7bbdca954cfbc48368d20cd81624bb297cb3a6e1513a13da12ec1d84d58",
+      "name": "prisma-client-5e1f7a411804d0c15f624cb274a52a054f81f0529069d799f8e739257332d03a",
       "version": "6.10.1"
     }
   }


### PR DESCRIPTION
The tiddlers *could* be combined into the "Entity" tiddler, but as they are now, each tiddler focuses on one of the concepts of an Entity, which i like.

**I am not sure which tag(s) to put on these. They may need to be tagged first.**

The first commit was an accident because i put the docs in /wiki/mws-docs instead of /mws-docs . The dates on the tiddlers are close together because i copied and pasted the text to the right one.
The first commit for some reason **changes  "version" from "0.1.0" to "0.1.9" and "prisma/client"."name"** .


I grabbed info from (more or less):
2025-02-18 - User Management
Application Access & Security
Access Control

Its more that bags and recipes are entities, so the bags and recipes tiddler may need to be changed to say that they are entities, 
but i wanted to add, not edit for this PR. 
Maybe that should be edited.
But the "bags and recipes" tiddler is talking more about the model, not how its implemented in MWS. So instead of editing that, two new tiddlers focusing on bags and recipes seperately would link to Entity. Maybe tagged by Entity?