### PR TITLE
Add file:// to import in mws.run.mjs

### DIFF
--- a/mws.run.mjs
+++ b/mws.run.mjs
@@ -19,7 +19,7 @@ if(!pkg?.dependencies?.["@tiddlywiki/mws"] || pkg.name !== "@tiddlywiki/mws-inst
   process.exit(1);
 }
 
-import(`${cwd}/node_modules/@tiddlywiki/mws/dist/mws.js`).then(mws => mws.default()).catch(console.error);
+import(`file://${cwd}/node_modules/@tiddlywiki/mws/dist/mws.js`).then(mws => mws.default()).catch(console.error);
 
 function tryParseJSON(file) {
   try {


### PR DESCRIPTION
Add `file://` to dynamic import to fix an error on Microsoft Windows.
Closes #86.
I dont know if there are any other dynamic imports in the project that have this issue.
<hr />

`process.cwd()` gives an absolute path.
On Linux, thats `/...`. On MS Windows, its `<drive letter>:\...`

`import()` accepts a string with an optional protocol. The protocol names are a string of letters and then an ending colon, like `file:`, `https:`, or `im-an-error:`

If you try to put `"C:\\index.js"` in `import`, it eats `C:` and cries about it not being a real protocol.

Putting `file://` at the start of the import path gives `import()` a protocol to chew on so that it parses everything afterwards as a path.