### PR TITLE
use /user/status for some paths

### DIFF
--- a/packages/react-admin/src/main.tsx
+++ b/packages/react-admin/src/main.tsx
@@ -2,12 +2,11 @@ import { StrictMode, Suspense, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import Login from './components/Login/Login';
 import { PageRoot } from './components/Dashboard/Frame';
-import { DataLoader, getIndexJson, IndexJsonContext } from './helpers/utils';
+import { DataLoader, getIndexJson, InfoJsonContext } from './helpers/utils';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
 import { ErrorBoundary } from "react-error-boundary";
 import { TestColors } from './colors';
-import { } from "@tiddlywiki/mws";
 const theme = createTheme({
   palette: {
     background: {
@@ -34,11 +33,11 @@ export const App = DataLoader(async () => {
     <StrictMode>
       <ThemeProvider theme={theme} defaultMode="system" noSsr>
         <CssBaseline enableColorScheme />
-        <IndexJsonContext.Provider value={[indexJson, refresh]}>
+        <InfoJsonContext.Provider value={[indexJson, refresh]}>
           <ErrorBoundary fallback={null} >
             {route === "/login" ? <Login /> : <PageRoot />}
           </ErrorBoundary>
-        </IndexJsonContext.Provider>
+        </InfoJsonContext.Provider>
       </ThemeProvider>
     </StrictMode>
     // <StrictMode>


### PR DESCRIPTION
I dont know how to write it right now, but im thinking, make the fetching lazy. have a "use" function that is for /`user`/status, and another for the regular `index`_json. If you use `user` and then `index`, the `index` upgrades the context from the one from `user` to the one from `index`. If it can't, then it panics. Frame can use the new `user` one.

I think the app panics in the app DataLoader. Somehow the loading needs to be put in a lazy thing.

At some point i will revert the first commit, and then throw stuff at this problem.