### PR TITLE
Add Contributor License Agreement section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+## Contributor License Agreement
+
+Contributors need to sign the TiddlyWiki CLA to, you know, contribute. \
+To sign the CLA, and understand what it means, [go here.](https://github.com/TiddlyWiki/TiddlyWiki5/blob/master/contributing.md#contributor-license-agreement)
+
 # MWS Server Architecture Explained
 
 This is a monorepo divided into separate projects. The entry point is in `packages/mws/src/index.ts`. The entry point imports the `server`, `commander`, and `events` projects. 


### PR DESCRIPTION
Added a Contributor License Agreement section in CONTRIBUTING.md with a link to the section in the TiddlyWiki repo. 

(copilot is doing commit messages now?)